### PR TITLE
EECI-6145: Update maintainer team for EECI owned services and repositories

### DIFF
--- a/.github/repo.yml
+++ b/.github/repo.yml
@@ -1,2 +1,2 @@
 #See (http://go/repository-config-as-code) for more details
-maintainer: roblox/eeci
+maintainer: roblox/eescm

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Roblox/eeci
+* @roblox/eescm


### PR DESCRIPTION
This is an auto generated PR. Please review and check for any potential issues before merging it.

Updates maintainer teams for repositories and services owned by EECI to reflect EE reorg to EESCM.

If the maintainer team has been incorrectly set to EECI or EESCM, please update the PR to the correct maintainer team.

[_Created by Sourcegraph batch change `roychiu/EECI-6145-switch-maintainer-eescm`._](https://sourcegraph.rbx.com/users/roychiu/batch-changes/EECI-6145-switch-maintainer-eescm)